### PR TITLE
Flush socket before send

### DIFF
--- a/UdpTransport.cs
+++ b/UdpTransport.cs
@@ -134,6 +134,9 @@ namespace SnmpSharpNet
 			{
 				try
 				{
+					while (_socket.Available > 0) // flush socket before send
+						_socket.ReceiveFrom(inbuffer, ref remote);
+						
 					_socket.SendTo(buffer, bufferLength, SocketFlags.None, (EndPoint)netPeer);
 					recv = _socket.ReceiveFrom(inbuffer, ref remote);
 				}


### PR DESCRIPTION
Flush socket before send to fix permanent SnmpException("Invalid request id in reply.") in case of receiving some unexpected reply packet